### PR TITLE
Chore: unify NuGet packages: 

### DIFF
--- a/GCFinal.Domain/GCFinal.Domain.csproj
+++ b/GCFinal.Domain/GCFinal.Domain.csproj
@@ -38,8 +38,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.6\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />

--- a/GCFinal.Domain/packages.config
+++ b/GCFinal.Domain/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.6" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
   <package id="popper.js" version="1.14.0" targetFramework="net472" />
   <package id="RestSharp" version="106.3.1" targetFramework="net472" />

--- a/GCFinal.MVC/GCFinal.MVC.csproj
+++ b/GCFinal.MVC/GCFinal.MVC.csproj
@@ -54,6 +54,9 @@
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="RestSharp, Version=106.3.1.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.3.1\lib\net452\RestSharp.dll</HintPath>
     </Reference>
@@ -109,9 +112,6 @@
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.4\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>

--- a/GCFinal.MVC/Web.config
+++ b/GCFinal.MVC/Web.config
@@ -19,7 +19,7 @@
     <add key="WeatherApiBaseUrl" value="http://localhost:56929/" />
   </appSettings>
   <system.web>
-    <customErrors mode="Off"/>
+    <customErrors mode="Off" />
     <compilation debug="true" targetFramework="4.7.2" />
     <httpRuntime targetFramework="4.7.2" />
     <httpModules>

--- a/GCFinal.MVC/packages.config
+++ b/GCFinal.MVC/packages.config
@@ -21,7 +21,7 @@
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.4" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Modernizr" version="2.8.3" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
   <package id="popper.js" version="1.14.0" targetFramework="net472" />
   <package id="RestSharp" version="106.3.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net472" />

--- a/GCFinal/GCFinal.API.csproj
+++ b/GCFinal/GCFinal.API.csproj
@@ -59,6 +59,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.6\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -75,9 +78,6 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>

--- a/GCFinal/Web.config
+++ b/GCFinal/Web.config
@@ -55,7 +55,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.6.0" newVersion="5.2.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/GCFinal/packages.config
+++ b/GCFinal/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.5.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.4" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.6" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net461" />


### PR DESCRIPTION
* Microsoft.AspNet.WebApi.Client as 5.2.6
* Newtonsoft.Json as 11.0.2

This will help avoid odd assembly version conflicts going forward.  It is good practice to keep all your projects on the same version.  I chose to use the latest, since it's only the bugfix version that changed on either package.