### PR TITLE
Chore: un-break the data migrations

### DIFF
--- a/GCFinal.Data/Migrations/201809201828095_InitialCreate.cs
+++ b/GCFinal.Data/Migrations/201809201828095_InitialCreate.cs
@@ -1,72 +1,54 @@
 namespace GCFinal.Data.Migrations
 {
-    using System;
     using System.Data.Entity.Migrations;
-    
+
     public partial class InitialCreate : DbMigration
     {
         public override void Up()
         {
-            CreateTable(
+            this.CreateTable(
                 "dbo.TripItems",
                 c => new
-                    {
-                        Id = c.Int(nullable: false, identity: true),
-                        Name = c.String(),
-                        Hot = c.Boolean(nullable: false),
-                        Warm = c.Boolean(nullable: false),
-                        Cool = c.Boolean(nullable: false),
-                        Cold = c.Boolean(nullable: false),
-                        IsRain = c.Boolean(nullable: false),
-                        IsWindy = c.Boolean(nullable: false),
-                        IsDaily = c.Boolean(nullable: false),
-                        IsEssential = c.Boolean(nullable: false),
-                        IsBulk = c.Boolean(nullable: false),
-                        Weight = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        Length = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        Width = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        Height = c.Decimal(nullable: false, precision: 18, scale: 2),
-                    })
+                {
+                    Id = c.Int(nullable: false, identity: true),
+                    Name = c.String(),
+                    Hot = c.Boolean(nullable: false),
+                    Warm = c.Boolean(nullable: false),
+                    Cool = c.Boolean(nullable: false),
+                    Cold = c.Boolean(nullable: false),
+                    IsRain = c.Boolean(nullable: false),
+                    IsWindy = c.Boolean(nullable: false),
+                    IsDaily = c.Boolean(nullable: false),
+                    IsEssential = c.Boolean(nullable: false),
+                    IsBulk = c.Boolean(nullable: false),
+                    Weight = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    Length = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    Width = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    Height = c.Decimal(nullable: false, precision: 18, scale: 2),
+                })
                 .PrimaryKey(t => t.Id);
-            
-            CreateTable(
+
+            this.CreateTable(
                 "dbo.PackingItems",
                 c => new
-                    {
-                        Id = c.Int(nullable: false, identity: true),
-                        TripId = c.Int(nullable: false),
-                        Name = c.String(),
-                        Weight = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        Length = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        Width = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        Height = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        Quantity = c.Decimal(nullable: false, precision: 18, scale: 2),
-                        TotalWeight = c.Decimal(nullable: false, precision: 18, scale: 2),
-                    })
-                .PrimaryKey(t => t.Id)
-                .ForeignKey("dbo.Trips", t => t.TripId, cascadeDelete: true)
-                .Index(t => t.TripId);
-            
-            CreateTable(
-                "dbo.Trips",
-                c => new
-                    {
-                        Id = c.Int(nullable: false, identity: true),
-                        Location = c.String(),
-                        StartDate = c.DateTime(nullable: false),
-                        Duration = c.Int(nullable: false),
-                    })
+                {
+                    Id = c.Int(nullable: false, identity: true),
+                    Name = c.String(),
+                    Weight = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    Length = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    Width = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    Height = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    Quantity = c.Decimal(nullable: false, precision: 18, scale: 2),
+                    TotalWeight = c.Decimal(nullable: false, precision: 18, scale: 2),
+                })
                 .PrimaryKey(t => t.Id);
-            
+
         }
-        
+
         public override void Down()
         {
-            DropForeignKey("dbo.PackingItems", "TripId", "dbo.Trips");
-            DropIndex("dbo.PackingItems", new[] { "TripId" });
-            DropTable("dbo.Trips");
-            DropTable("dbo.PackingItems");
-            DropTable("dbo.TripItems");
+            this.DropTable("dbo.PackingItems");
+            this.DropTable("dbo.TripItems");
         }
     }
 }


### PR DESCRIPTION
You can't have the db created with the Trips table, then also add the same table in the first migration.  Logically that is a conflict because you are trying to create the same SQL object twice.  This isn't a problem in the live version, but it is a problem if you try to run it locally from scratch (i.e. for working on new development).